### PR TITLE
イベントハンドラの解除漏れ修正

### DIFF
--- a/VCasJsonManager/ViewModels/ConfigEditViewModel.cs
+++ b/VCasJsonManager/ViewModels/ConfigEditViewModel.cs
@@ -202,6 +202,7 @@ namespace VCasJsonManager.ViewModels
                     {
                         RaiseAllPropertyChanged();
                         CompositeDisposable.Remove(ConfigJsonListner);
+                        ConfigJsonListner.Dispose();
                         addConfigJsonListner();
                     }
                 },

--- a/VCasJsonManager/ViewModels/DirectViewDialogViewModel.cs
+++ b/VCasJsonManager/ViewModels/DirectViewDialogViewModel.cs
@@ -83,6 +83,7 @@ namespace VCasJsonManager.ViewModels
                     {
                         RaiseAllPropertyChanged();
                         CompositeDisposable.Remove(ConfigJsonListner);
+                        ConfigJsonListner.Dispose();
                         addConfigJsonListner();
                     }
                 },

--- a/VCasJsonManager/ViewModels/PresetControlViewModel.cs
+++ b/VCasJsonManager/ViewModels/PresetControlViewModel.cs
@@ -112,6 +112,7 @@ namespace VCasJsonManager.ViewModels
             if (ConfigJsonEventListener != null)
             {
                 CompositeDisposable.Remove(ConfigJsonEventListener);
+                ConfigJsonEventListener.Dispose();
             }
 
             ConfigJsonEventListener = new PropertyChangedEventListener(ConfigJsonService.ConfigJson)

--- a/VCasJsonManager/ViewModels/VrDebugDialogViewModel.cs
+++ b/VCasJsonManager/ViewModels/VrDebugDialogViewModel.cs
@@ -104,6 +104,7 @@ namespace VCasJsonManager.ViewModels
                     {
                         RaiseAllPropertyChanged();
                         CompositeDisposable.Remove(ConfigJsonListner);
+                        ConfigJsonListner.Dispose();
                         addConfigJsonListner();
                     }
                 },


### PR DESCRIPTION
ConfigJsonオブジェクト変更時に、ViewModelにてEventListenerをCompositDisposableからRemoveしていたが、RemoveしたEventLstenerをDisposeしていなかったため、イベントハンドラの解除が行われていない問題を修正