### PR TITLE
リスト項目並べ替え時に、上書き保存保存ボタンが有効にならない問題の修正

### DIFF
--- a/VCasJsonManager/Services/ICollectionManageService.cs
+++ b/VCasJsonManager/Services/ICollectionManageService.cs
@@ -3,13 +3,14 @@
 // Copyright 2019 TOMA
 // MIT License
 //
+using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using VCasJsonManager.Models;
 
 namespace VCasJsonManager.Services
 {
-    public interface ICollectionManageService<T> : INotifyPropertyChanged, INotifyDataErrorInfo
+    public interface ICollectionManageService<T> : INotifyPropertyChanged, INotifyDataErrorInfo, IDisposable
     {
         ObservableCollection<T> Collection { get; }
         ConfigJson ConfigJson { get; }

--- a/VCasJsonManager/Services/Impl/CollectionManageService.cs
+++ b/VCasJsonManager/Services/Impl/CollectionManageService.cs
@@ -73,6 +73,17 @@ namespace VCasJsonManager.Services.Impl
             UriConversionService = uriConversionService;
             ConfigJson = configJsonService.ConfigJson;
             SelectCollectionFunc = selectFunc;
+            Collection.CollectionChanged += Collection_CollectionChanged;
+        }
+
+        /// <summary>
+        /// Collectionの変更通知処理
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void Collection_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            ConfigJson.IsChanged = true;
         }
 
         /// <summary>
@@ -83,7 +94,6 @@ namespace VCasJsonManager.Services.Impl
             if (ValidateAndCreateNewItem(out var item))
             {
                 Collection.Add(item);
-                ConfigJson.IsChanged = true;
             }
         }
 
@@ -94,7 +104,6 @@ namespace VCasJsonManager.Services.Impl
         public void RemoveAt(int index)
         {
             Collection.RemoveAt(index);
-            ConfigJson.IsChanged = true;
         }
 
         /// <summary>
@@ -103,7 +112,6 @@ namespace VCasJsonManager.Services.Impl
         public void RemoveAll()
         {
             Collection.Clear();
-            ConfigJson.IsChanged = true;
         }
 
         /// <summary>
@@ -173,6 +181,25 @@ namespace VCasJsonManager.Services.Impl
         protected void RaiseErrorChanged(string propertyName)
         {
             ErrorsChanged?.Invoke(this, new DataErrorsChangedEventArgs(propertyName));
+        }
+
+        /// <summary>
+        /// ディスポーズ済みフラグ
+        /// </summary>
+        private bool disposed = false;
+
+        /// <summary>
+        /// Dispose
+        /// </summary>
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            Collection.CollectionChanged -= Collection_CollectionChanged;
         }
     }
 }

--- a/VCasJsonManagerTests/Services/Impl/CollectionManageServiceTests.cs
+++ b/VCasJsonManagerTests/Services/Impl/CollectionManageServiceTests.cs
@@ -65,6 +65,7 @@ namespace VCasJsonManager.Services.Impl.Tests
             target = new CollectionManagerStub(collection);
             ErrorChangedCalled = new List<string>();
             target.ErrorsChanged += (_, e) => ErrorChangedCalled.Add(e.PropertyName);
+            target.ConfigJson.IsChanged = false;
         }
 
         [TestMethod()]
@@ -78,6 +79,7 @@ namespace VCasJsonManager.Services.Impl.Tests
             CollectionAssert.AreEqual(new[] { "Value" }, collection);
             Assert.IsFalse(target.HasErrors);
             Assert.IsNull(target.GetErrors(nameof(CollectionManagerStub.InputValue)));
+            Assert.IsTrue(target.ConfigJson.IsChanged);
         }
 
         [TestMethod()]
@@ -90,6 +92,7 @@ namespace VCasJsonManager.Services.Impl.Tests
             Assert.IsFalse(target.Collection.Any());
             Assert.IsTrue(target.HasErrors);
             CollectionAssert.AreEqual(new[] { "It's Error" }, target.GetErrors(nameof(CollectionManagerStub.InputValue)).OfType<string>().ToArray());
+            Assert.IsFalse(target.ConfigJson.IsChanged);
         }
 
 
@@ -115,9 +118,11 @@ namespace VCasJsonManager.Services.Impl.Tests
             target.AddNewItem();
             target.newItem = "Value2";
             target.AddNewItem();
+            target.ConfigJson.IsChanged = false;
 
             target.RemoveAt(0);
             CollectionAssert.AreEqual(new[] { "Value2" }, target.Collection);
+            Assert.IsTrue(target.ConfigJson.IsChanged);
         }
 
         [TestMethod()]
@@ -127,9 +132,18 @@ namespace VCasJsonManager.Services.Impl.Tests
             target.AddNewItem();
             target.newItem = "Value2";
             target.AddNewItem();
+            target.ConfigJson.IsChanged = false;
 
             target.RemoveAll();
             Assert.IsFalse(target.Collection.Any());
+            Assert.IsTrue(target.ConfigJson.IsChanged);
+        }
+
+        [TestMethod()]
+        public void Collection_CollectionChangedTest()
+        {
+            collection.Add("Value");
+            Assert.IsTrue(target.ConfigJson.IsChanged);
         }
     }
 }


### PR DESCRIPTION
・CollectionManageServiceにて、リスト項目のCollectionChangedでConfigJsonのIsChangedをtrueとするよう修正